### PR TITLE
Set search input box color

### DIFF
--- a/_sass/search.scss
+++ b/_sass/search.scss
@@ -48,6 +48,7 @@
   padding-bottom: $sp-2;
   padding-left: #{$gutter-spacing-sm + $sp-5};
   font-size: 16px;
+  color: $body-text-color;
   background-color: $search-background-color;
   border-top: 0;
   border-right: 0;


### PR DESCRIPTION
Search box text in dark theme does not meet accessibility requirements as it was using black text on a dark grey background.

This was fixed in the original just-the-docs repo so just propagating the fix to here.